### PR TITLE
Fixed broken link for the Apache license

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,4 +172,4 @@ When committing, remember to use `npm run commit`, in order to start commitizen.
 
 ## LICENSE
 
-[Apache 2.0](LICENSE)
+[Apache 2.0](LICENSE.md)


### PR DESCRIPTION
The link for the Apache License was broken in the Readme. 
Upon clicking on the link, it would give a 404.
The reason for that is that the extension for the file was not provided. 

On providing the extension, it fixes the broken link.


![image](https://user-images.githubusercontent.com/22765689/120478451-7cd3d680-c3ca-11eb-9b96-e1c0ccd51ffd.png)
